### PR TITLE
refactor: change hook name useActiveNavItem to useScrollSpy

### DIFF
--- a/.changeset/wild-islands-smash.md
+++ b/.changeset/wild-islands-smash.md
@@ -1,0 +1,5 @@
+---
+'@raddix/use-scroll-spy': minor
+---
+
+Added the useScrollSpy hook

--- a/packages/utilities/use-active-nav-item/CHANGELOG.md
+++ b/packages/utilities/use-active-nav-item/CHANGELOG.md
@@ -1,7 +1,0 @@
-# @raddix/use-active-nav-item
-
-## 0.1.0
-
-### Minor Changes
-
-- a62a7f1: Added the useActiveNavItem hook

--- a/packages/utilities/use-scroll-spy/README.md
+++ b/packages/utilities/use-scroll-spy/README.md
@@ -41,4 +41,4 @@ const App = () => {
 
 ## Documentation
 
-For full documentation, visit [raddix.website/use-scroll-spy](https://www.raddix.website/docs/utilities/use-toggle)
+For full documentation, visit [raddix.website/use-scroll-spy](https://www.raddix.website/docs/utilities/use-scroll-spy)

--- a/packages/utilities/use-scroll-spy/README.md
+++ b/packages/utilities/use-scroll-spy/README.md
@@ -1,0 +1,44 @@
+<div align="center">
+  <h1 align="center">useScrollSpy</h1>
+  <a href="https://github.com/gdvu/raddix/blob/main/LICENSE">
+    <img alt="GitHub" src="https://img.shields.io/github/license/gdvu/raddix">
+  </a>
+  <a href="https://www.npmjs.com/package/@raddix/use-toggle">
+    <img alt="npm version" src="https://img.shields.io/npm/v/@raddix/use-scroll-spy">
+  </a>
+
+  <a href="https://www.npmjs.com/package/@raddix/use-toggle">
+  <img alt="npm bundle size" src="https://img.shields.io/bundlephobia/min/@raddix/use-scroll-spy">
+  </a>
+</div>
+<p align="center">
+Automatically update navigation based on scroll position.
+</p>
+
+## Install
+
+```bash
+npm i @raddix/use-scroll-spy
+# or
+yarn add @raddix/use-scroll-spy
+# or
+pnpm add @raddix/use-scroll-spy
+```
+
+## Usage
+
+```jsx
+import { useScrollSpy } from '@raddix/use-scroll-spy';
+
+const App = () => {
+  const navList = ['home', 'work', 'about', 'contact'];
+
+  const navActive = useScrollSpy(navList, { threshold: 0.7 });
+
+  ...
+};
+```
+
+## Documentation
+
+For full documentation, visit [raddix.website/use-scroll-spy](https://www.raddix.website/docs/utilities/use-toggle)

--- a/packages/utilities/use-scroll-spy/examples/section-indicator.tsx
+++ b/packages/utilities/use-scroll-spy/examples/section-indicator.tsx
@@ -1,4 +1,4 @@
-import { useActiveNavItem } from '@raddix/use-active-nav-item';
+import { useScrollSpy } from '@raddix/use-scroll-spy';
 
 const Section = ({ name, bg }: { bg: string; name: string }) => (
   <section
@@ -12,7 +12,7 @@ const Section = ({ name, bg }: { bg: string; name: string }) => (
 export const SectionIndicator = () => {
   const navList = ['home', 'work', 'about', 'contact'];
 
-  const navActive = useActiveNavItem(navList, { threshold: 0.6 });
+  const navActive = useScrollSpy(navList, { threshold: 0.6 });
 
   return (
     <div className='bg-black'>

--- a/packages/utilities/use-scroll-spy/package.json
+++ b/packages/utilities/use-scroll-spy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@raddix/use-scroll-spy",
   "description": "Automatically update navigation based on scroll position.",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "license": "MIT",
   "main": "src/index.ts",
   "author": "Moises Machuca Valverde <rolan.machuca@gmail.com> (https://www.moisesmachuca.com)",

--- a/packages/utilities/use-scroll-spy/package.json
+++ b/packages/utilities/use-scroll-spy/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@raddix/use-active-nav-item",
-  "description": "Indicates which navigation element is active.",
+  "name": "@raddix/use-scroll-spy",
+  "description": "Automatically update navigation based on scroll position.",
   "version": "0.1.0",
   "license": "MIT",
   "main": "src/index.ts",
@@ -11,10 +11,10 @@
     "url": "https://github.com/gdvu/raddix.git"
   },
   "keywords": [
-    "raddix",
-    "active-nav",
-    "active-item",
-    "active-heading"
+    "scrollspy",
+    "react-use-scrollspy",
+    "react-scrollspy",
+    "hook-scrollspy"
   ],
   "sideEffects": false,
   "scripts": {

--- a/packages/utilities/use-scroll-spy/src/index.ts
+++ b/packages/utilities/use-scroll-spy/src/index.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-export const useActiveNavItem = (
+export const useScrollSpy = (
   items: string[],
   options?: IntersectionObserverInit
 ): string => {
@@ -8,9 +8,7 @@ export const useActiveNavItem = (
 
   useEffect(() => {
     const observer = new IntersectionObserver(entries => {
-      entries.forEach(e =>
-        e.isIntersecting ? setActiveId(e.target.id) : null
-      );
+      entries.forEach(e => e.isIntersecting && setActiveId(e.target.id));
     }, options);
 
     items.forEach(id => {

--- a/packages/utilities/use-scroll-spy/stories/SectionIndicator.stories.tsx
+++ b/packages/utilities/use-scroll-spy/stories/SectionIndicator.stories.tsx
@@ -4,7 +4,7 @@ import { SectionIndicator } from '../examples/section-indicator';
 
 const meta: Meta<typeof SectionIndicator> = {
   component: SectionIndicator,
-  title: 'useActiveNavItem'
+  title: 'useScrollSpy'
 };
 
 export default meta;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,7 +209,7 @@ importers:
         version: 18.2.0(react@18.2.0)
     publishDirectory: dist
 
-  packages/utilities/use-active-nav-item:
+  packages/utilities/use-scroll-spy:
     dependencies:
       react:
         specifier: '>=16.8.0'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "paths": {
       "@raddix/switch": ["./packages/primitives/switch/src"],
-      "@raddix/use-active-nav-item": [
-        "./packages/utilities/use-active-nav-item/src"
-      ],
+      "@raddix/use-scroll-spy": ["./packages/utilities/use-scroll-spy/src"],
       "@raddix/use-toggle": ["./packages/utilities/use-toggle/src"],
       "@raddix/use-keyboard": ["./packages/interactions/use-keyboard/src"]
     }


### PR DESCRIPTION
## 📝 Description:

Change hook name useActiveNavItem to useScrollSpy


## ✅ Pull Request Checklist:

- [x] Add/Update feature.
- [ ] Add/Update test.
- [x] Add/Update documentation.
- [x] Add/Update stories in storybook.
- [ ] Bug fix.
- [x] Is this a breaking change

## Demo

![use-scroll-spy](https://github.com/vintach/raddix/assets/60050894/6a873de4-7267-417b-a0bb-8dd984b7641b)
