### PR TITLE
feat: add useClickOutside hook

### DIFF
--- a/.changeset/purple-rings-check.md
+++ b/.changeset/purple-rings-check.md
@@ -1,0 +1,5 @@
+---
+'@raddix/use-click-outside': minor
+---
+
+Added the useClickOutside hook

--- a/packages/interactions/use-click-outside/README.md
+++ b/packages/interactions/use-click-outside/README.md
@@ -3,16 +3,16 @@
   <a href="https://github.com/gdvu/raddix/blob/main/LICENSE">
     <img alt="GitHub" src="https://img.shields.io/github/license/gdvu/raddix">
   </a>
-  <a href="https://www.npmjs.com/package/@raddix/use-toggle">
+  <a href="https://www.npmjs.com/package/@raddix/use-click-outside">
     <img alt="npm version" src="https://img.shields.io/npm/v/@raddix/use-click-outside">
   </a>
 
-  <a href="https://www.npmjs.com/package/@raddix/use-toggle">
+  <a href="https://www.npmjs.com/package/@raddix/use-click-outside">
   <img alt="npm bundle size" src="https://img.shields.io/bundlephobia/min/@raddix/use-click-outside">
   </a>
 </div>
 <p align="center">
-Automatically update navigation based on scroll position.
+`useClickOutside` is a custom hook for listening clicks outside of a specific element.
 </p>
 
 ## Install
@@ -23,20 +23,6 @@ npm i @raddix/use-click-outside
 yarn add @raddix/use-click-outside
 # or
 pnpm add @raddix/use-click-outside
-```
-
-## Usage
-
-```jsx
-import { useScrollSpy } from '@raddix/use-click-outside';
-
-const App = () => {
-  const navList = ['home', 'work', 'about', 'contact'];
-
-  const navActive = useScrollSpy(navList, { threshold: 0.7 });
-
-  ...
-};
 ```
 
 ## Documentation

--- a/packages/interactions/use-click-outside/README.md
+++ b/packages/interactions/use-click-outside/README.md
@@ -1,0 +1,44 @@
+<div align="center">
+  <h1 align="center">useClickOutside</h1>
+  <a href="https://github.com/gdvu/raddix/blob/main/LICENSE">
+    <img alt="GitHub" src="https://img.shields.io/github/license/gdvu/raddix">
+  </a>
+  <a href="https://www.npmjs.com/package/@raddix/use-toggle">
+    <img alt="npm version" src="https://img.shields.io/npm/v/@raddix/use-click-outside">
+  </a>
+
+  <a href="https://www.npmjs.com/package/@raddix/use-toggle">
+  <img alt="npm bundle size" src="https://img.shields.io/bundlephobia/min/@raddix/use-click-outside">
+  </a>
+</div>
+<p align="center">
+Automatically update navigation based on scroll position.
+</p>
+
+## Install
+
+```bash
+npm i @raddix/use-click-outside
+# or
+yarn add @raddix/use-click-outside
+# or
+pnpm add @raddix/use-click-outside
+```
+
+## Usage
+
+```jsx
+import { useScrollSpy } from '@raddix/use-click-outside';
+
+const App = () => {
+  const navList = ['home', 'work', 'about', 'contact'];
+
+  const navActive = useScrollSpy(navList, { threshold: 0.7 });
+
+  ...
+};
+```
+
+## Documentation
+
+For full documentation, visit [raddix.website/use-click-outside](https://www.raddix.website/docs/utilities/use-click-outside)

--- a/packages/interactions/use-click-outside/package.json
+++ b/packages/interactions/use-click-outside/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@raddix/use-click-outside",
+  "description": "",
+  "version": "0.0.0",
+  "license": "MIT",
+  "source": "src/index.ts",
+  "main": "src/index.ts",
+  "author": "Moises Machuca Valverde <rolan.machuca@gmail.com> (https://www.moisesmachuca.com)",
+  "homepage": "https://www.raddix.website",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gdvu/raddix.git"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "lint": "eslint \"{src,tests}/*.{ts,tsx,css}\"",
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
+    "build": "tsup src --dts",
+    "prepack": "clean-package",
+    "postpack": "clean-package restore"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+  },
+  "clean-package": "../../../clean-package.config.json",
+  "tsup": {
+    "clean": true,
+    "target": "es2019",
+    "format": [
+      "cjs",
+      "esm"
+    ]
+  }
+}

--- a/packages/interactions/use-click-outside/package.json
+++ b/packages/interactions/use-click-outside/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raddix/use-click-outside",
-  "description": "",
+  "description": "Lisen clicks outside of a specific element",
   "version": "0.0.0",
   "license": "MIT",
   "source": "src/index.ts",

--- a/packages/interactions/use-click-outside/src/index.ts
+++ b/packages/interactions/use-click-outside/src/index.ts
@@ -1,0 +1,27 @@
+import type { RefObject } from 'react';
+import { useEffect } from 'react';
+
+type Event = MouseEvent | TouchEvent;
+type Handler = (event: Event) => void;
+
+export const useClickOutside = <T extends HTMLElement = HTMLElement>(
+  ref: RefObject<T>,
+  handler: Handler
+): void => {
+  useEffect(() => {
+    const callback = (event: Event) => {
+      const el = ref.current;
+
+      if (!el || el.contains(event.target as Node)) return;
+
+      handler(event);
+    };
+
+    document.addEventListener('mousedown', callback);
+    document.addEventListener('touchstart', callback);
+    return () => {
+      document.removeEventListener('mousedown', callback);
+      document.removeEventListener('touchstart', callback);
+    };
+  }, [ref, handler]);
+};

--- a/packages/interactions/use-click-outside/tests/use-click-outside.test.tsx
+++ b/packages/interactions/use-click-outside/tests/use-click-outside.test.tsx
@@ -1,0 +1,27 @@
+import { createRef } from 'react';
+import { renderHook, fireEvent, render, screen } from '@testing-library/react';
+import { useClickOutside } from '@raddix/use-click-outside';
+
+describe('useClickOutside', () => {
+  it('should call the function when the click is outside the element', () => {
+    const handler = jest.fn();
+    const ref = createRef<HTMLDivElement>();
+    render(<div ref={ref}></div>);
+
+    renderHook(() => useClickOutside(ref, handler));
+    fireEvent.mouseDown(document.body);
+
+    expect(handler).toBeCalledTimes(1);
+  });
+
+  it('should not call the function when the element is clicked', () => {
+    const handler = jest.fn();
+    const ref = createRef<HTMLDivElement>();
+    render(<div ref={ref} data-testid='container'></div>);
+
+    renderHook(() => useClickOutside(ref, handler));
+    fireEvent.mouseDown(screen.getByTestId('container'));
+
+    expect(handler).not.toBeCalled();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,15 @@ importers:
         specifier: ~4.9
         version: 4.9.3
 
+  packages/interactions/use-click-outside:
+    dependencies:
+      react:
+        specifier: '>=16.8.0'
+        version: 18.2.0
+      react-dom:
+        specifier: '>=16.8.0'
+        version: 18.2.0(react@18.2.0)
+
   packages/interactions/use-keyboard:
     dependencies:
       react:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,10 @@
       "@raddix/switch": ["./packages/primitives/switch/src"],
       "@raddix/use-scroll-spy": ["./packages/utilities/use-scroll-spy/src"],
       "@raddix/use-toggle": ["./packages/utilities/use-toggle/src"],
-      "@raddix/use-keyboard": ["./packages/interactions/use-keyboard/src"]
+      "@raddix/use-keyboard": ["./packages/interactions/use-keyboard/src"],
+      "@raddix/use-click-outside": [
+        "./packages/interactions/use-click-outside/src"
+      ]
     }
   },
   "include": ["packages"],


### PR DESCRIPTION
## 📝 Description:
`useClickOutside` is a custom hook for listening clicks outside of a specific element.

## ✅ Pull Request Checklist:

- [x] Add/Update feature.
- [x] Add/Update test.
- [x] Add/Update documentation.
- [ ] Add/Update stories in storybook.
- [ ] Bug fix.
- [ ] Is this a breaking change



