### PR TITLE
feat(useKeyboard): add support for global keyboard events

### DIFF
--- a/.changeset/tame-guests-work.md
+++ b/.changeset/tame-guests-work.md
@@ -1,0 +1,5 @@
+---
+'@raddix/use-keyboard': minor
+---
+
+Add support global keyboard events.

--- a/packages/interactions/use-keyboard/src/use-keyboard.ts
+++ b/packages/interactions/use-keyboard/src/use-keyboard.ts
@@ -1,9 +1,13 @@
-import type { KeyboardEvent } from 'react';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { useEffect } from 'react';
 import type { Keys } from './keys';
 
-type KeyboardHandler = (event: KeyboardEvent) => void;
+type Event = ReactKeyboardEvent | KeyboardEvent;
+type KeyboardHandler = (event: Event) => void;
+type KeyboardResult = (event: ReactKeyboardEvent) => void;
 
 interface Options {
+  globalEvent?: boolean;
   stopPropagation?: boolean;
   preventDefault?: boolean;
   checker?: 'key' | 'code';
@@ -13,16 +17,17 @@ type UseKeyboard = (
   handler: KeyboardHandler,
   shortcut?: Keys[],
   options?: Options
-) => KeyboardHandler;
+) => KeyboardResult;
 
 export const useKeyboard: UseKeyboard = (handler, shortcut, options = {}) => {
   const {
+    globalEvent = false,
     preventDefault = false,
     stopPropagation = true,
     checker = 'key'
   } = options;
 
-  const eventHandler = (event: KeyboardEvent) => {
+  const eventHandler = (event: Event) => {
     if (shortcut && shortcut.length > 0) {
       const match = shortcut.includes(event[checker]);
 
@@ -39,6 +44,17 @@ export const useKeyboard: UseKeyboard = (handler, shortcut, options = {}) => {
 
     handler(event);
   };
+
+  useEffect(() => {
+    if (globalEvent) {
+      document.addEventListener('keydown', eventHandler);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', eventHandler);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [globalEvent]);
 
   return eventHandler;
 };

--- a/packages/interactions/use-keyboard/tests/use-keyboard.test.tsx
+++ b/packages/interactions/use-keyboard/tests/use-keyboard.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render } from '@testing-library/react';
-import { useKeyboard } from '@raddix/use-keyboard';
+import { fireEvent, render, renderHook } from '@testing-library/react';
+import { useKeyboard } from '../src/index';
 
 interface ComponentProps {
   onKeyboard: (event: React.KeyboardEvent | KeyboardEvent) => void;
@@ -85,5 +85,13 @@ describe('useKeyboard test:', () => {
       { type: 'keydown', key: 'KeyS' },
       { type: 'keydown', key: 'KeyG' }
     ]);
+  });
+
+  it('should allow shortcuts globally', () => {
+    const handler = jest.fn();
+    renderHook(() => useKeyboard(handler, ['c'], { globalEvent: true }));
+    fireEvent.keyDown(document.body, { key: 'c' });
+
+    expect(handler).toBeCalledTimes(1);
   });
 });

--- a/packages/primitives/switch/src/types.ts
+++ b/packages/primitives/switch/src/types.ts
@@ -1,7 +1,7 @@
 import type {
   ChangeEvent,
   ComponentPropsWithoutRef,
-  KeyboardEvent,
+  KeyboardEvent as ReactKeyboardEvent,
   MouseEvent,
   ElementType,
   InputHTMLAttributes,
@@ -40,7 +40,11 @@ export interface SwitchState extends Checked, Disabled {
   setChecked: Dispatch<SetStateAction<boolean>>;
 }
 
-export type Event = MouseEvent | KeyboardEvent | ChangeEvent;
+export type Event =
+  | MouseEvent
+  | ReactKeyboardEvent
+  | ChangeEvent
+  | KeyboardEvent;
 
 export interface DataAttrSwitch {
   'data-state'?: DataState;


### PR DESCRIPTION
## 📝 Description:

Add support for global keyboard events by using the `globalEvent: true` option

## ✅ Pull Request Checklist:

- [x] Add/Update feature.
- [x] Add/Update test.
- [ ] Add/Update documentation.
- [ ] Add/Update stories in storybook.
- [ ] Bug fix.
- [ ] Is this a breaking change



