### PR TITLE
feat(useCounter): add `onMin()` and `onMax()` functions in options

### DIFF
--- a/.changeset/stale-lamps-tan.md
+++ b/.changeset/stale-lamps-tan.md
@@ -1,0 +1,6 @@
+---
+'@raddix/use-counter': minor
+---
+
+Added `onMin` function to run when the counter reaches the minimum value.
+Added `onMax` function to run when the counter reaches the maximum value.

--- a/packages/utilities/use-counter/src/index.ts
+++ b/packages/utilities/use-counter/src/index.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-interface Actions {
+export interface Actions {
   /** Increments the counter, default by 1 */
   inc: (value?: number) => void;
   /** Decrements the counter, default by 1 */
@@ -11,11 +11,15 @@ interface Actions {
   set: (value: number) => void;
 }
 
-interface Options {
+export interface Options {
   /** The minimum value of the counter */
   min?: number;
   /** The maximum value of the counter */
   max?: number;
+  /** Function to execute when the counter reaches the minimum value */
+  onMin?: () => void;
+  /** Function to execute when the counter reaches the maximum value */
+  onMax?: () => void;
 }
 
 type UseCounter = (
@@ -39,11 +43,15 @@ export const useCounter: UseCounter = (initialValue, options = {}) => {
   );
 
   const inc = (value = 1) => {
-    setCounter(prev => max(prev + value, options.max));
+    const nextValue = max(counter + value, options.max);
+    setCounter(nextValue);
+    if (nextValue === options.max && options.onMax) options.onMax();
   };
 
   const dec = (value = 1) => {
-    setCounter(prev => min(prev - value, options.min));
+    const prevValue = min(counter - value, options.min);
+    setCounter(prevValue);
+    if (prevValue === options.min && options.onMin) options.onMin();
   };
 
   const reset = () => {

--- a/packages/utilities/use-counter/tests/use-counter.test.ts
+++ b/packages/utilities/use-counter/tests/use-counter.test.ts
@@ -89,4 +89,38 @@ describe('useCounter test:', () => {
 
     expect(result.current[0]).toBe(10);
   });
+
+  test('should execute onMin callback', () => {
+    const onMin = jest.fn();
+    const { result } = renderHook(() => useCounter(5, { min: 0, onMin }));
+
+    act(() => {
+      result.current[1].dec(4);
+    });
+
+    expect(onMin).not.toBeCalled();
+
+    act(() => {
+      result.current[1].dec(4);
+    });
+
+    expect(onMin).toBeCalled();
+  });
+
+  test('should execute onMax callback', () => {
+    const onMax = jest.fn();
+    const { result } = renderHook(() => useCounter(0, { max: 5, onMax }));
+
+    act(() => {
+      result.current[1].inc(4);
+    });
+
+    expect(onMax).not.toBeCalled();
+
+    act(() => {
+      result.current[1].inc(4);
+    });
+
+    expect(onMax).toBeCalled();
+  });
 });


### PR DESCRIPTION
## 📝 Description:

Added `onMin()` function to run when the counter reaches the minimum value and `onMax()` function to run when the counter reaches the maximum value.


## ✅ Pull Request Checklist:

- [x] Add/Update feature.
- [x] Add/Update test.
- [ ] Add/Update documentation.
- [ ] Add/Update stories in storybook.
- [ ] Bug fix.
- [ ] Is this a breaking change



