### PR TITLE
feat: add useTimeout hook

### DIFF
--- a/.changeset/pretty-chicken-agree.md
+++ b/.changeset/pretty-chicken-agree.md
@@ -1,0 +1,5 @@
+---
+'@raddix/use-timeout': major
+---
+
+Added the useTimeout hook

--- a/packages/interactions/use-timeout/README.md
+++ b/packages/interactions/use-timeout/README.md
@@ -1,0 +1,5 @@
+# useTimeout
+
+The `useTimeout` hook is used to execute a callback after a specified amount of time. It is similar to the `setTimeout` function, but it is declarative and can be cancelled.
+
+Please refer to the [documentation](https://www.raddix.website/docs/interactions/use-timeout) for more information.

--- a/packages/interactions/use-timeout/package.json
+++ b/packages/interactions/use-timeout/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@raddix/use-timeout",
+  "description": "A React hook for handling timeouts",
+  "version": "0.1.0",
+  "license": "MIT",
+  "main": "src/index.ts",
+  "author": "Moises Machuca Valverde <rolan.machuca@gmail.com> (https://www.moisesmachuca.com)",
+  "homepage": "https://www.raddix.website",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gdvu/raddix.git"
+  },
+  "keywords": [
+    "react-hook",
+    "react-timeout-hook",
+    "react-timeout",
+    "react-use-timeout",
+    "use-timeout",
+    "use-timeout-hook",
+    "hook-timeout"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "lint": "eslint \"{src,tests}/*.{ts,tsx,css}\"",
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
+    "build": "tsup src --dts",
+    "prepack": "clean-package",
+    "postpack": "clean-package restore"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
+  },
+  "clean-package": "../../../clean-package.config.json",
+  "tsup": {
+    "clean": true,
+    "target": "es2019",
+    "format": [
+      "cjs",
+      "esm"
+    ]
+  }
+}

--- a/packages/interactions/use-timeout/src/index.ts
+++ b/packages/interactions/use-timeout/src/index.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+
+type UseTimeout = (cb: () => void, delay: number) => () => void;
+
+export const useTimeout: UseTimeout = (cb, delay) => {
+  const savedCallback = useRef(cb);
+  const id = useRef<NodeJS.Timeout | null>(null);
+
+  const clearId = () => {
+    if (!id.current) return;
+    clearTimeout(id.current);
+    id.current = null;
+  };
+
+  useEffect(() => {
+    savedCallback.current = cb;
+  }, [cb]);
+
+  useEffect(() => {
+    const tick = () => savedCallback.current();
+    id.current = setTimeout(tick, delay);
+    return () => clearId();
+  }, [delay]);
+
+  return clearId;
+};

--- a/packages/interactions/use-timeout/tests/use-timeout.test.ts
+++ b/packages/interactions/use-timeout/tests/use-timeout.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react';
+import { useTimeout } from '../src';
+
+describe('useTimeout test:', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('the timeout should work', () => {
+    const callback = jest.fn();
+    renderHook(() => useTimeout(callback, 1000));
+
+    expect(callback).not.toBeCalled();
+    jest.advanceTimersByTime(2000);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should clear the timeout when the component unmounts', () => {
+    const callback = jest.fn();
+    const { unmount } = renderHook(() => useTimeout(callback, 1000));
+
+    expect(callback).not.toBeCalled();
+    unmount();
+    jest.advanceTimersByTime(2000);
+    expect(callback).not.toBeCalled();
+  });
+
+  it('should clear the timeout when the delay changes', () => {
+    const callback = jest.fn();
+    const { rerender } = renderHook(
+      ({ delay }) => useTimeout(callback, delay),
+      {
+        initialProps: { delay: 1000 }
+      }
+    );
+
+    expect(callback).not.toBeCalled();
+    rerender({ delay: 2000 });
+    jest.advanceTimersByTime(1000);
+    expect(callback).not.toBeCalled();
+    jest.advanceTimersByTime(4000);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should stop the timeout when the clear function is called', () => {
+    const callback = jest.fn();
+    const { result } = renderHook(() => useTimeout(callback, 4000));
+
+    expect(callback).not.toBeCalled();
+    jest.advanceTimersByTime(2000);
+    result.current();
+    jest.advanceTimersByTime(2000);
+    expect(callback).not.toBeCalled();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,15 @@ importers:
         specifier: '>=16.8.0'
         version: 18.2.0(react@18.2.0)
 
+  packages/interactions/use-timeout:
+    dependencies:
+      react:
+        specifier: '>=16.8.0'
+        version: 18.2.0
+      react-dom:
+        specifier: '>=16.8.0'
+        version: 18.2.0(react@18.2.0)
+
   packages/primitives/switch:
     dependencies:
       '@raddix/use-keyboard':
@@ -6859,7 +6868,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr@1.1.4:
@@ -8112,9 +8121,9 @@ packages:
       eslint-plugin-es: 4.1.0(eslint@8.39.0)
       eslint-utils: 3.0.0(eslint@8.39.0)
       ignore: 5.2.4
-      is-core-module: 2.12.1
+      is-core-module: 2.13.0
       minimatch: 3.1.2
-      resolve: 1.22.2
+      resolve: 1.22.6
       semver: 7.5.4
     dev: true
 
@@ -8834,14 +8843,6 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
-
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
 
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -10102,7 +10103,7 @@ packages:
       micromatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /jest-leak-detector@29.6.1:
@@ -12593,7 +12594,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /run-applescript@5.0.0:


### PR DESCRIPTION
## 📝 Description:

The `useTimeout` hook is used to execute a callback after a specified amount of time. It is similar to the `setTimeout` function, but it is declarative and can be cancelled.


## ✅ Pull Request Checklist:

- [x] Add/Update feature.
- [x] Add/Update test.
- [ ] Add/Update documentation.
- [ ] Add/Update stories in storybook.
- [ ] Bug fix.
- [ ] Is this a breaking change



